### PR TITLE
Fix: optimize providers to avoid unnecessary API client reinstantiation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,7 +10,10 @@
     "build-docs": "typedoc --options typedoc.json",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(tsx|ts|json)\""
   },
-  "keywords": ["React", "Planship"],
+  "keywords": [
+    "React",
+    "Planship"
+  ],
   "author": "Pawel Wojnarowicz",
   "license": "MIT",
   "devDependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,3 +4,7 @@ export interface ProviderConfig {
   websocketUrl?: string
   getAccessToken: (forceRefresh: boolean) => Promise<string>
 }
+
+export interface CustomerProviderConfig extends ProviderConfig {
+  customerId: string
+}

--- a/src/withPlanshipCustomerProvider.tsx
+++ b/src/withPlanshipCustomerProvider.tsx
@@ -2,26 +2,24 @@ import React, { ReactNode, useState, useEffect } from 'react'
 
 import { CustomerSubscriptionWithPlan, PlanshipCustomer, JSONValue } from '@planship/fetch'
 import { Provider } from './customerContext'
-import { ProviderConfig } from './types'
+import { CustomerProviderConfig } from './types'
 
 export default function withPlanshipCustomerProvider(
-  config: ProviderConfig,
+  config: CustomerProviderConfig,
   initialEntitlements: JSONValue,
   initialSubscriptions: CustomerSubscriptionWithPlan[]
 ) {
-  const { url, websocketUrl, slug, getAccessToken } = config
+  const { url, websocketUrl, slug, getAccessToken, customerId } = config
 
-  let planshipCustomerApiClient: PlanshipCustomer
+  const planshipCustomerApiClient = new PlanshipCustomer(
+    slug,
+    customerId,
+    url || 'https://api.planship.io',
+    getAccessToken,
+    websocketUrl
+  )
 
-  const PlanshipCustomerProvider = ({ children, customerId }: { children: ReactNode; customerId: string }) => {
-    planshipCustomerApiClient = new PlanshipCustomer(
-      slug,
-      customerId,
-      url || 'https://api.planship.io',
-      getAccessToken,
-      websocketUrl
-    )
-
+  const PlanshipCustomerProvider = ({ children }: { children: ReactNode }) => {
     const [entitlements, setEntitlements] = useState(initialEntitlements)
     const [subscriptions, setSubscriptions] = useState(initialSubscriptions)
 

--- a/src/withPlanshipProvider.tsx
+++ b/src/withPlanshipProvider.tsx
@@ -6,9 +6,9 @@ import { ProviderConfig } from './types'
 
 export default function withPlanshipProvider(config: ProviderConfig) {
   const { url, websocketUrl, slug, getAccessToken } = config
+  const planshipApiClient = new Planship(slug, url || 'https://api.planship.io', getAccessToken, websocketUrl)
 
   const PlanshipProvider = ({ children }: { children: ReactNode }) => {
-    const planshipApiClient = new Planship(slug, url || 'https://api.planship.io', getAccessToken, websocketUrl)
     return <Provider value={{ planshipApiClient }}>{children}</Provider>
   }
 


### PR DESCRIPTION
This PR, when merged, will refactor provider initialization code so API client instances are not recreated on every rerender.