### PR TITLE
New @planship/fetch constructors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/react",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -32,6 +32,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@planship/fetch": "0.1.1"
+    "@planship/fetch": "0.2.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@planship/fetch':
-    specifier: 0.1.1
-    version: 0.1.1
+    specifier: 0.2.1
+    version: 0.2.1
 
 devDependencies:
   '@types/react':
@@ -140,14 +140,14 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dev: true
 
-  /@planship/fetch@0.1.1:
-    resolution: {integrity: sha512-QNbFAx6pTKckx61cUtM68+eU+z6m4TkLBYjhbnFl3kdO7x+amAapIddcgO4rQ3lkWQ9b36n58ASRoP2cHiat4A==}
+  /@planship/fetch@0.2.1:
+    resolution: {integrity: sha512-/KdPVqXXAGHbgVRsX6tLsjhS8fZYI+simvJeGwxltOMg7Eeud2mUDG75g0BkOf2iQLeOUlYV9GJJYUIElXYN+Q==}
     dependencies:
-      '@planship/models': 0.1.0
+      '@planship/models': 0.2.1
     dev: false
 
-  /@planship/models@0.1.0:
-    resolution: {integrity: sha512-/8Tlu3SmUemVNAeNJlUsf7vUwKRNxzCytDW61NEC9HWcYqonqF7WfVVuOvc/SC7/ovmf6alVxhZhJTcIqFVKWQ==}
+  /@planship/models@0.2.1:
+    resolution: {integrity: sha512-Tw2wMFp4+IZZmnubngMEV6RXXCUx/rX/FDLPImR5QKh0qVuRomAh21n22X9FIl2Qi8GcHiLIQ4geNlxuP7AQzw==}
     dev: false
 
   /@types/json-schema@7.0.15:

--- a/src/customerContext.ts
+++ b/src/customerContext.ts
@@ -1,10 +1,10 @@
-import { CustomerSubscriptionWithPlan, JSONValue, PlanshipCustomer } from '@planship/fetch'
+import { CustomerSubscriptionWithPlan, Entitlements, PlanshipCustomer } from '@planship/fetch'
 
 import { createContext } from 'react'
 
 interface IPlanshipCustomerContext {
   planshipCustomerApiClient?: PlanshipCustomer
-  entitlements: JSONValue
+  entitlements: Entitlements
   subscriptions: CustomerSubscriptionWithPlan[]
 }
 const context = createContext<IPlanshipCustomerContext>({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
+import { TokenGetter } from '@planship/fetch'
+
 export interface ProviderConfig {
-  url?: string
+  baseUrl?: string
   slug: string
-  websocketUrl?: string
-  getAccessToken: (forceRefresh: boolean) => Promise<string>
+  webSocketUrl?: string
+  getAccessToken: TokenGetter
 }
 
 export interface CustomerProviderConfig extends ProviderConfig {

--- a/src/withPlanshipCustomerProvider.tsx
+++ b/src/withPlanshipCustomerProvider.tsx
@@ -1,23 +1,20 @@
 import React, { ReactNode, useState, useEffect } from 'react'
 
-import { CustomerSubscriptionWithPlan, PlanshipCustomer, JSONValue } from '@planship/fetch'
+import { CustomerSubscriptionWithPlan, PlanshipCustomer, Entitlements } from '@planship/fetch'
 import { Provider } from './customerContext'
 import { CustomerProviderConfig } from './types'
 
 export default function withPlanshipCustomerProvider(
   config: CustomerProviderConfig,
-  initialEntitlements: JSONValue,
+  initialEntitlements: Entitlements,
   initialSubscriptions: CustomerSubscriptionWithPlan[]
 ) {
-  const { url, websocketUrl, slug, getAccessToken, customerId } = config
+  const { baseUrl, webSocketUrl, slug, getAccessToken, customerId } = config
 
-  const planshipCustomerApiClient = new PlanshipCustomer(
-    slug,
-    customerId,
-    url || 'https://api.planship.io',
-    getAccessToken,
-    websocketUrl
-  )
+  const planshipCustomerApiClient = new PlanshipCustomer(slug, customerId, getAccessToken, {
+    baseUrl,
+    webSocketUrl
+  })
 
   const PlanshipCustomerProvider = ({ children }: { children: ReactNode }) => {
     const [entitlements, setEntitlements] = useState(initialEntitlements)

--- a/src/withPlanshipProvider.tsx
+++ b/src/withPlanshipProvider.tsx
@@ -5,8 +5,11 @@ import { Provider } from './context'
 import { ProviderConfig } from './types'
 
 export default function withPlanshipProvider(config: ProviderConfig) {
-  const { url, websocketUrl, slug, getAccessToken } = config
-  const planshipApiClient = new Planship(slug, url || 'https://api.planship.io', getAccessToken, websocketUrl)
+  const { baseUrl, webSocketUrl, slug, getAccessToken } = config
+  const planshipApiClient = new Planship(slug, getAccessToken, {
+    baseUrl,
+    webSocketUrl
+  })
 
   const PlanshipProvider = ({ children }: { children: ReactNode }) => {
     return <Provider value={{ planshipApiClient }}>{children}</Provider>


### PR DESCRIPTION
This PR, when merged, will update the `@planship/fetch` version used by this SDK to 0.2.1 that change how parameters are passed to Planship API client constructors.
Related PR: https://github.com/planship/planship-js/pull/8