### PR TITLE
Move to @planship/fetch 0.2.2  - access token reuse fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -32,6 +32,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@planship/fetch": "0.2.1"
+    "@planship/fetch": "^0.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@planship/fetch':
-    specifier: 0.2.1
-    version: 0.2.1
+    specifier: ^0.2.2
+    version: 0.2.2
 
 devDependencies:
   '@types/react':
@@ -140,8 +140,8 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dev: true
 
-  /@planship/fetch@0.2.1:
-    resolution: {integrity: sha512-/KdPVqXXAGHbgVRsX6tLsjhS8fZYI+simvJeGwxltOMg7Eeud2mUDG75g0BkOf2iQLeOUlYV9GJJYUIElXYN+Q==}
+  /@planship/fetch@0.2.2:
+    resolution: {integrity: sha512-5QoTCBoqOsOjJjiYhNC39HX7vbiYgnF08YQocT2wlrZO0s9CVIwZwS6CsOQDzqvFIlyk2m/9WFKmmA2TQaW8jQ==}
     dependencies:
       '@planship/models': 0.2.1
     dev: false


### PR DESCRIPTION
This PR, when merged, will update its @planship/fetch dependency to version 0.2.2 that contains PlanshipCustomer access token reuse.
Related PR: https://github.com/planship/planship-js/pull/9