### PR TITLE
ES module configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": [
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "require-extensions"
   ],
   "extends": [
     "eslint:recommended",
@@ -10,7 +11,8 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
-    "prettier"
+    "prettier",
+    "plugin:require-extensions/recommended"
   ],
   "settings": {
     "react": {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pnpm add @planship/react
 
 The `Planship` context provider is designed to be initialized at the very top of your layout where the Planship customer ID might not be known (E.g. outside of your authed layout).
 
-With `@planship/react` added to your project, initialize `PlanshipProvider` using the `withPlanshipProvider` function, and wrap your components with it.
+With `@planship/react` added to your project, initialize `PlanshipProvider` using `withPlanshipProvider`, and wrap your components with it.
 
 ```js
 import { withPlanshipProvider } from '@planship/react'

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@planship/react",
-  "version": "0.3.0",
+  "version": "0.3.1-alpha1",
   "description": "",
   "main": "dist/index.js",
+  "type": "module",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc",
@@ -27,6 +28,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-require-extensions": "^0.1.3",
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "typedoc": "^0.25.13",
@@ -34,6 +36,6 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@planship/fetch": "0.3.0"
+    "@planship/fetch": "0.3.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@planship/fetch':
-    specifier: 0.3.0
-    version: 0.3.0
+    specifier: 0.3.2
+    version: 0.3.2
 
 devDependencies:
   '@types/react':
@@ -34,6 +34,9 @@ devDependencies:
   eslint-plugin-react-hooks:
     specifier: ^4.6.2
     version: 4.6.2(eslint@8.57.0)
+  eslint-plugin-require-extensions:
+    specifier: ^0.1.3
+    version: 0.1.3(eslint@8.57.0)
   prettier:
     specifier: ^3.3.3
     version: 3.3.3
@@ -137,14 +140,14 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dev: true
 
-  /@planship/fetch@0.3.0:
-    resolution: {integrity: sha512-DlZvFacTCixakLqo4OXpomEzyto0Sd4dFo2597INiOQEffvHq55e4dkyybZ/Oc+r4Ij9sPovnf5T9+czU594zQ==}
+  /@planship/fetch@0.3.2:
+    resolution: {integrity: sha512-u9AhXxttCt/J2+Q++uxqFGliPWedk5gSXoMMKKSSRUJJLIC4i+rYZHYN6643VheCaVrIZmeg5cngVUSEHfT4dQ==}
     dependencies:
-      '@planship/models': 0.3.0
+      '@planship/models': 0.3.2
     dev: false
 
-  /@planship/models@0.3.0:
-    resolution: {integrity: sha512-j9bN0b6pVQ94EZdOI4I9FdfYYMipXkydNmUaGdRrm78QY5iZiCGRhF57B+tnJm6EB7ZaJTG07FzE2ad9mO9GJg==}
+  /@planship/models@0.3.2:
+    resolution: {integrity: sha512-PMfuIegyXIIReoQ6mo11HcNG0eGwZQRN6YKYlGcGHNzPyg8Ls2rBWqEtMo3Him956HlE3RmyYmO4oO89ejCo4Q==}
     dev: false
 
   /@types/prop-types@15.7.12:
@@ -765,6 +768,15 @@ packages:
       string.prototype.repeat: 1.0.0
     dev: true
 
+  /eslint-plugin-require-extensions@0.1.3(eslint@8.57.0):
+    resolution: {integrity: sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      eslint: 8.57.0
+    dev: true
+
   /eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1047,7 +1059,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.19.2
+      uglify-js: 3.19.3
     dev: true
 
   /has-bigints@1.0.2:
@@ -1948,8 +1960,8 @@ packages:
     hasBin: true
     dev: true
 
-  /uglify-js@3.19.2:
-    resolution: {integrity: sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==}
+  /uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import withPlanshipProvider from './withPlanshipProvider'
-import withPlanshipCustomerProvider from './withPlanshipCustomerProvider'
-import { usePlanship } from './usePlanship'
-import { usePlanshipCustomer } from './usePlanshipCustomer'
-import { EntitlementsBase } from './types'
+import withPlanshipProvider from './withPlanshipProvider.js'
+import withPlanshipCustomerProvider from './withPlanshipCustomerProvider.js'
+import { usePlanship } from './usePlanship.js'
+import { usePlanshipCustomer } from './usePlanshipCustomer.js'
+import { EntitlementsBase } from './types.js'
 
 export { withPlanshipProvider, withPlanshipCustomerProvider, usePlanship, usePlanshipCustomer, EntitlementsBase }
 

--- a/src/usePlanship.ts
+++ b/src/usePlanship.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 
-import context, { type IPlanshipContext } from './context'
+import context, { type IPlanshipContext } from './context.js'
 
 const usePlanship = () => {
   return useContext<IPlanshipContext>(context)

--- a/src/usePlanshipCustomer.ts
+++ b/src/usePlanshipCustomer.ts
@@ -1,8 +1,8 @@
 import { useContext } from 'react'
 
-import context, { type IPlanshipCustomerContext } from './customerContext'
+import context, { type IPlanshipCustomerContext } from './customerContext.js'
 import type { Entitlements, PlanshipCustomer } from '@planship/fetch'
-import { EntitlementsBase } from './types'
+import { EntitlementsBase } from './types.js'
 
 interface ICustomerContext<T extends EntitlementsBase> {
   planshipCustomerApiClient?: PlanshipCustomer

--- a/src/withPlanshipCustomerProvider.tsx
+++ b/src/withPlanshipCustomerProvider.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode, useState, useEffect } from 'react'
 
 import { PlanshipCustomer, type Entitlements } from '@planship/fetch'
-import { Provider } from './customerContext'
-import type { CustomerProviderConfig } from './types'
+import { Provider } from './customerContext.js'
+import type { CustomerProviderConfig } from './types.js'
 
 export default function withPlanshipCustomerProvider(
   config: CustomerProviderConfig,

--- a/src/withPlanshipProvider.tsx
+++ b/src/withPlanshipProvider.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode } from 'react'
 
 import { Planship } from '@planship/fetch'
-import { Provider } from './context'
-import type { ProviderConfig } from './types'
+import { Provider } from './context.js'
+import type { ProviderConfig } from './types.js'
 
 export default function withPlanshipProvider(config: ProviderConfig) {
   const { baseUrl, webSocketUrl, slug, getAccessToken } = config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "es2020"                                   /* Specify what module code is generated. */,
+    "module": "NodeNext"                                   /* Specify what module code is generated. */,
     "rootDir": "src"                                     /* Specify the root folder within your source files. */,
-    "moduleResolution": "node"                           /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "moduleResolution": "NodeNext"                           /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
This PR, when merged, will change the tsconfig/package configuration to ESM module that targets ESNext.

This configuration change required adding .js file extensions to all relative imports, and replacing all directory imports with file imports (E.g. import * from ./dir -> import * from ./dir/index.js). For auto-generated code (OpenAPI gen), this was a minor configuration change. For internally written code, file extensions are enforced using the 'eslint-plugin-require-extensions' plugin (errors can be auto-fixed too).